### PR TITLE
add script to create udev rules ;; device name is /dev/dynamixel_motors

### DIFF
--- a/dynamixel_driver/scripts/58-dynamixel_configurator.rules
+++ b/dynamixel_driver/scripts/58-dynamixel_configurator.rules
@@ -1,0 +1,3 @@
+# On precise, for some reason, USER and GROUP are getting ignored.
+# So setting mode = 0666 for now.
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{manufacturer}=="BestTechnology", MODE:="0666", GROUP:="dialout", SYMLINK+="dynamixel_motors"

--- a/dynamixel_driver/scripts/create_udev_rules
+++ b/dynamixel_driver/scripts/create_udev_rules
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo ""
+echo "This script copies a udev rule to /etc to facilitate bringing"
+echo "up the dynamixel configurator connection as /dev/ttyUSB?."
+echo ""
+
+sudo cp `rospack find dynamixel_driver`/scripts/58-dynamixel_configurator.rules /etc/udev/rules.d
+
+
+echo ""
+echo "Restarting udev"
+echo ""
+sudo service udev reload
+sudo service udev restart
+


### PR DESCRIPTION
Hi, Arebgun,

I created new scripts to configure udev files. 
By using these scripts, we can generate /dev/dynamixel_motors
instead of /dev/ttyUSB?. 
We just need to run 
  rosrun dynamixel_motor create_udev_rules
command. 

Could you merge this change?
