### PR TITLE
Fixed syntax error due to missing parentheses

### DIFF
--- a/dynamixel_controllers/src/dynamixel_controllers/joint_trajectory_action_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_trajectory_action_controller.py
@@ -149,8 +149,8 @@ class JointTrajectoryActionController():
             res = FollowJointTrajectoryResult(FollowJointTrajectoryResult.INVALID_JOINTS)
             msg = 'Incoming trajectory joints do not match the joints of the controller'
             rospy.logerr(msg)
-            rospy.logerr(' self.joint_names={}' % (set(self.joint_names))
-            rospy.logerr(' traj.joint_names={}' % (set(traj.joint_names))
+            rospy.logerr(' self.joint_names={}' % (set(self.joint_names)))
+            rospy.logerr(' traj.joint_names={}' % (set(traj.joint_names)))
             self.action_server.set_aborted(result=res, text=msg)
             return
             


### PR DESCRIPTION
My program kept refusing to start the `joint_trajectory_action_controller` due to some unbalanced parentheses. This should fix it.