### PR TITLE
remove deprecated functions from dynamixel_io

### DIFF
--- a/dynamixel_controllers/launch/dynamixel_manager.launch
+++ b/dynamixel_controllers/launch/dynamixel_manager.launch
@@ -1,0 +1,14 @@
+<launch>
+    <node name="dynamixel_manager" pkg="dynamixel_controllers" type="controller_manager.py" required="true" output="screen">
+        <rosparam>
+            namespace: dxl_manager
+            serial_ports:
+                ttyUSB0:
+                    port_name: "/dev/ttyUSB0"
+                    baud_rate: 1000000
+                    min_motor_id: 0
+                    max_motor_id: 30
+                    update_rate: 200
+        </rosparam>
+    </node>
+</launch>

--- a/dynamixel_controllers/launch/motor.yaml
+++ b/dynamixel_controllers/launch/motor.yaml
@@ -1,0 +1,12 @@
+motor_controller:
+    controller:
+        package: dynamixel_controllers
+        module: joint_position_controller
+        type: JointPositionController
+    joint_name: spin_joint
+    joint_speed: 11.0
+    motor:
+        id: 8
+        init: 0
+        min: 0
+        max: 1023

--- a/dynamixel_controllers/launch/position.launch
+++ b/dynamixel_controllers/launch/position.launch
@@ -1,0 +1,9 @@
+<launch>
+    <!-- Start tilt joint controller -->
+    <rosparam file="$(find dynamixel_controllers)/launch/motor.yaml" command="load"/>
+    <node name="motor_controller_spawner" pkg="dynamixel_controllers" type="controller_spawner.py"
+          args="--manager=dxl_manager
+                --port ttyUSB0
+                motor_controller"
+          output="screen"/>
+</launch>

--- a/dynamixel_driver/src/dynamixel_driver/dynamixel_io.py
+++ b/dynamixel_driver/src/dynamixel_driver/dynamixel_io.py
@@ -64,9 +64,7 @@ class DynamixelIO(object):
         try:
             self.serial_mutex = Lock()
             self.ser = None
-            self.ser = serial.Serial(port)
-            self.ser.setTimeout(0.015)
-            self.ser.baudrate = baudrate
+            self.ser = serial.Serial(port, baudrate, timeout=0.015)
             self.port_name = port
             self.readback_echo = readback_echo
         except SerialOpenError:


### PR DESCRIPTION
After upgrading my PySerial version to V3.0 (current version), dynamixel_driver/dynamixel_io.py failed on the call to Serial.setTimeout(). Throwing the following error:

`'Serial' object has no attribute 'setTimeout'`

From this issue, https://github.com/pyserial/pyserial/issues/66 it looks like the set/get functions were deprecated in V2.x and completely removed in V3.0.