### PR TITLE
Set serial timeout as property, not function call

### DIFF
--- a/dynamixel_driver/src/dynamixel_driver/dynamixel_io.py
+++ b/dynamixel_driver/src/dynamixel_driver/dynamixel_io.py
@@ -65,7 +65,7 @@ class DynamixelIO(object):
             self.serial_mutex = Lock()
             self.ser = None
             self.ser = serial.Serial(port)
-            self.ser.setTimeout(0.015)
+            self.ser.timeout = 0.015
             self.ser.baudrate = baudrate
             self.port_name = port
             self.readback_echo = readback_echo


### PR DESCRIPTION
Ths is needed for the driver to work with the version of pyserial on Ubuntu 16.04, and so is needed for ROS kinetic. Otherwise the driver crashes because the `Serial.setTimeout()` function no longer exists:

```
 Traceback (most recent call last):
   File "/opt/iron_ox/src/third_party/dynamixel_motor/dynamixel_controllers/nodes/controller_manager.py", line 266, in <module>
     manager = ControllerManager()
   File "/opt/iron_ox/src/third_party/dynamixel_motor/dynamixel_controllers/nodes/controller_manager.py", line 107, in __init__
     serial_proxy.connect()
   File "/opt/iron_ox/src/third_party/dynamixel_motor/dynamixel_driver/src/dynamixel_driver/dynamixel_serial_proxy.py", line 99, in connect
     self.dxl_io = dynamixel_io.DynamixelIO(self.port_name, self.baud_rate, self.readback_echo)
   File "/opt/iron_ox/src/third_party/dynamixel_mo
tor/dynamixel_driver/src/dynamixel_driver/dynamixel_io.py", line 68, in __init__
     self.ser.setTimeout(0.015)
 AttributeError: 'Serial' object has no attribute 'setTimeout'
 [dynamixel_manager-4] process has died [pid 16595, exit code 1, cmd /opt/iron_ox/src/third_party/dynamixel_motor/dynamixel_controllers/nodes/controller_manager.py __name:=dynamixel_manager __log:=/home
```

It looks like the property are the "correct" way to set the timeout now: https://github.com/pyserial/pyserial/issues/66

Could someone running indigo/14.04 check that this is backwards compatible?