### PR TITLE
Fix EX-106 motor id in control table. Fixes #60

### DIFF
--- a/dynamixel_driver/src/dynamixel_driver/dynamixel_const.py
+++ b/dynamixel_driver/src/dynamixel_driver/dynamixel_const.py
@@ -235,7 +235,7 @@ DXL_MODEL_TO_PARAMS = \
            'rpm_per_tick':       0.111,
            'features':           []
          },
-    107: { 'name':               'EX-106',
+    106: { 'name':               'EX-106',
            'encoder_resolution': 4096,
            'range_degrees':      250.92,
            'torque_per_volt':    10.9 / 18.5,                      # 10.9 NM @ 18.5V


### PR DESCRIPTION
So for some reason the lookup ID for the EX-106 in the `dynamixel_const.py` file was set to 107. I now tested with a real servo and it reports 106. After changing things, the servo works correctly now.