### PR TITLE
Use services to set position, or speed and position instead of topics

### DIFF
--- a/dynamixel_controllers/CMakeLists.txt
+++ b/dynamixel_controllers/CMakeLists.txt
@@ -11,6 +11,7 @@ add_service_files(
   SetComplianceSlope.srv
   SetPosition.srv
   SetSpeed.srv
+  SetSpeedandPosition.srv
   SetTorqueLimit.srv
   StartController.srv
   StopController.srv

--- a/dynamixel_controllers/CMakeLists.txt
+++ b/dynamixel_controllers/CMakeLists.txt
@@ -9,6 +9,7 @@ add_service_files(
   SetComplianceMargin.srv
   SetCompliancePunch.srv
   SetComplianceSlope.srv
+  SetPosition.srv
   SetSpeed.srv
   SetTorqueLimit.srv
   StartController.srv

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
@@ -49,6 +49,7 @@ from dynamixel_driver.dynamixel_const import *
 
 from dynamixel_controllers.srv import SetPosition
 from dynamixel_controllers.srv import SetSpeed
+from dynamixel_controllers.srv import SetSpeedandPosition
 from dynamixel_controllers.srv import TorqueEnable
 from dynamixel_controllers.srv import SetComplianceSlope
 from dynamixel_controllers.srv import SetComplianceMargin
@@ -76,6 +77,7 @@ class JointController:
         
         self.speed_service = rospy.Service(self.controller_namespace + '/set_speed', SetSpeed, self.process_set_speed)
         self.position_service = rospy.Service(self.controller_namespace + '/set_position', SetPosition, self.process_set_position)
+        self.speed_position_service = rospy.Service(self.controller_namespace + '/set_speed_and_position', SetSpeedandPosition, self.process_set_speed_and_position)
         self.torque_service = rospy.Service(self.controller_namespace + '/torque_enable', TorqueEnable, self.process_torque_enable)
         self.compliance_slope_service = rospy.Service(self.controller_namespace + '/set_compliance_slope', SetComplianceSlope, self.process_set_compliance_slope)
         self.compliance_marigin_service = rospy.Service(self.controller_namespace + '/set_compliance_margin', SetComplianceMargin, self.process_set_compliance_margin)
@@ -146,9 +148,12 @@ class JointController:
         self.set_speed(req.speed)
         return [] # success
 
+    def process_set_speed_and_position(self, req):
+        self.set_speed(req.speed)
+        return self.set_position(req.position, req.timeout)
+
     def process_set_position(self, req):
-        self.set_position(req.position, req.timeout)
-        return [] # success
+        return self.set_position(req.position, req.timeout)
 
     def process_torque_enable(self, req):
         self.set_torque_enable(req.torque_enable)

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
@@ -47,6 +47,7 @@ import rospy
 
 from dynamixel_driver.dynamixel_const import *
 
+from dynamixel_controllers.srv import SetPosition
 from dynamixel_controllers.srv import SetSpeed
 from dynamixel_controllers.srv import TorqueEnable
 from dynamixel_controllers.srv import SetComplianceSlope
@@ -74,6 +75,7 @@ class JointController:
         self.__ensure_limits()
         
         self.speed_service = rospy.Service(self.controller_namespace + '/set_speed', SetSpeed, self.process_set_speed)
+        self.position_service = rospy.Service(self.controller_namespace + '/set_position', SetPosition, self.process_set_position)
         self.torque_service = rospy.Service(self.controller_namespace + '/torque_enable', TorqueEnable, self.process_torque_enable)
         self.compliance_slope_service = rospy.Service(self.controller_namespace + '/set_compliance_slope', SetComplianceSlope, self.process_set_compliance_slope)
         self.compliance_marigin_service = rospy.Service(self.controller_namespace + '/set_compliance_margin', SetComplianceMargin, self.process_set_compliance_margin)
@@ -115,6 +117,7 @@ class JointController:
         self.motor_states_sub.unregister()
         self.command_sub.unregister()
         self.speed_service.shutdown('normal shutdown')
+        self.position_service.shutdown('normal shutdown')
         self.torque_service.shutdown('normal shutdown')
         self.compliance_slope_service.shutdown('normal shutdown')
 
@@ -122,6 +125,9 @@ class JointController:
         raise NotImplementedError
 
     def set_speed(self, speed):
+        raise NotImplementedError
+
+    def set_position(self, position, timeout):
         raise NotImplementedError
 
     def set_compliance_slope(self, slope):
@@ -138,6 +144,10 @@ class JointController:
 
     def process_set_speed(self, req):
         self.set_speed(req.speed)
+        return [] # success
+
+    def process_set_position(self, req):
+        self.set_position(req.position, req.timeout)
         return [] # success
 
     def process_torque_enable(self, req):

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
@@ -129,7 +129,7 @@ class JointController:
     def set_speed(self, speed):
         raise NotImplementedError
 
-    def set_position(self, position, timeout):
+    def set_position(self, position):
         raise NotImplementedError
 
     def set_compliance_slope(self, slope):
@@ -150,10 +150,10 @@ class JointController:
 
     def process_set_speed_and_position(self, req):
         self.set_speed(req.speed)
-        return self.set_position(req.position, req.timeout)
+        return self.set_position(req.position)
 
     def process_set_position(self, req):
-        return self.set_position(req.position, req.timeout)
+        return self.set_position(req.position)
 
     def process_torque_enable(self, req):
         self.set_torque_enable(req.torque_enable)

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -132,23 +132,21 @@ class JointPositionController(JointController):
         mcv = (self.motor_id, self.spd_rad_to_raw(speed))
         self.dxl_io.set_multi_speed([mcv])
 
-    def set_position(self, position, timeout=5.0):
+    def set_position(self, position):
         response = False
-        timeout = 5.0 if timeout < 5.0 	else timeout
         angle = position
         mcv = (self.motor_id, self.pos_rad_to_raw(angle))
         self.dxl_io.set_multi_position([mcv])
-        timer = 0.0
-        rospy.sleep(0.5)
 
-        while self.joint_state.is_moving and timer <= timeout:
-            timer += 0.1
+        # Without this small sleep we fail to get self.joint_state.is_moving as
+        # it is still False.
+        rospy.sleep(0.25)
+
+        while self.joint_state.is_moving:
             rospy.sleep(0.1)
 
-        diff = abs(self.joint_state.current_pos - position)
-        if diff < 0.1:
+        if abs(self.joint_state.current_pos - position) < 0.1:
             response = True
-        
         return response
 
     def set_compliance_slope(self, slope):

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -132,6 +132,21 @@ class JointPositionController(JointController):
         mcv = (self.motor_id, self.spd_rad_to_raw(speed))
         self.dxl_io.set_multi_speed([mcv])
 
+    def set_position(self, position, timeout=1.0):
+        response = False
+        angle = position
+        mcv = (self.motor_id, self.pos_rad_to_raw(angle))
+        self.dxl_io.set_multi_position([mcv])
+        timer = 0.0
+
+        while self.joint_state.is_moving and timer <= timeout:
+            timer += 0.01
+            rospy.sleep(0.01)
+
+        if abs(self.joint_state.current_pos - position) > 0.05:
+            response = True
+        return response
+
     def set_compliance_slope(self, slope):
         if slope < DXL_MIN_COMPLIANCE_SLOPE: slope = DXL_MIN_COMPLIANCE_SLOPE
         elif slope > DXL_MAX_COMPLIANCE_SLOPE: slope = DXL_MAX_COMPLIANCE_SLOPE

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -132,19 +132,23 @@ class JointPositionController(JointController):
         mcv = (self.motor_id, self.spd_rad_to_raw(speed))
         self.dxl_io.set_multi_speed([mcv])
 
-    def set_position(self, position, timeout=1.0):
+    def set_position(self, position, timeout=5.0):
         response = False
+        timeout = 5.0 if timeout < 5.0 	else timeout
         angle = position
         mcv = (self.motor_id, self.pos_rad_to_raw(angle))
         self.dxl_io.set_multi_position([mcv])
         timer = 0.0
+        rospy.sleep(0.5)
 
         while self.joint_state.is_moving and timer <= timeout:
-            timer += 0.01
-            rospy.sleep(0.01)
+            timer += 0.1
+            rospy.sleep(0.1)
 
-        if abs(self.joint_state.current_pos - position) > 0.05:
+        diff = abs(self.joint_state.current_pos - position)
+        if diff < 0.1:
             response = True
+        
         return response
 
     def set_compliance_slope(self, slope):

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -133,21 +133,25 @@ class JointPositionController(JointController):
         self.dxl_io.set_multi_speed([mcv])
 
     def set_position(self, position):
-        response = False
+        goal_reached = False
+        min_max_limit_reached = False
         angle = position
+        limit = 0.1
         mcv = (self.motor_id, self.pos_rad_to_raw(angle))
         self.dxl_io.set_multi_position([mcv])
 
-        # Without this small sleep we fail to get self.joint_state.is_moving as
-        # it is still False.
-        rospy.sleep(0.25)
+        # Without this sleep we fail to get self.joint_state.is_moving as it is still False.
+        rospy.sleep(0.1)
 
         while self.joint_state.is_moving:
             rospy.sleep(0.1)
 
-        if abs(self.joint_state.current_pos - position) < 0.1:
-            response = True
-        return response
+        if abs(self.joint_state.current_pos - position) < limit:
+            goal_reached = True
+        if abs(self.max_angle - self.joint_state.goal_pos) < limit or \
+                        abs(self.min_angle - self.joint_state.goal_pos) < limit:
+            min_max_limit_reached = True
+        return (goal_reached, min_max_limit_reached)
 
     def set_compliance_slope(self, slope):
         if slope < DXL_MIN_COMPLIANCE_SLOPE: slope = DXL_MIN_COMPLIANCE_SLOPE

--- a/dynamixel_controllers/srv/SetPosition.srv
+++ b/dynamixel_controllers/srv/SetPosition.srv
@@ -1,4 +1,5 @@
 float64 position
 ---
 bool goal_reached
+bool min_max_limit_reached
 

--- a/dynamixel_controllers/srv/SetPosition.srv
+++ b/dynamixel_controllers/srv/SetPosition.srv
@@ -1,0 +1,5 @@
+float64 position
+float64 timeout
+---
+bool goal_reached
+

--- a/dynamixel_controllers/srv/SetPosition.srv
+++ b/dynamixel_controllers/srv/SetPosition.srv
@@ -1,5 +1,4 @@
 float64 position
-float64 timeout
 ---
 bool goal_reached
 

--- a/dynamixel_controllers/srv/SetSpeedandPosition.srv
+++ b/dynamixel_controllers/srv/SetSpeedandPosition.srv
@@ -2,4 +2,5 @@ float64 speed
 float64 position
 ---
 bool goal_reached
+bool min_max_limit_reached
 

--- a/dynamixel_controllers/srv/SetSpeedandPosition.srv
+++ b/dynamixel_controllers/srv/SetSpeedandPosition.srv
@@ -1,0 +1,6 @@
+float64 speed
+float64 position
+float64 timeout
+---
+bool goal_reached
+

--- a/dynamixel_controllers/srv/SetSpeedandPosition.srv
+++ b/dynamixel_controllers/srv/SetSpeedandPosition.srv
@@ -1,6 +1,5 @@
 float64 speed
 float64 position
-float64 timeout
 ---
 bool goal_reached
 


### PR DESCRIPTION
The advantage of services over topic communication is that we immediately get a response from the service. Thus giving the behavior coordination system on a robot the chance to base a decision on the response. For this I added bool values goal_reached and min_max_limit_reached to the service definitions and implemented he handling within joint_position_controller.py and joint_controller.py
Feedback welcome.