### PR TITLE
Fix formatting in error message

### DIFF
--- a/dynamixel_controllers/src/dynamixel_controllers/joint_trajectory_action_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_trajectory_action_controller.py
@@ -150,8 +150,8 @@ class JointTrajectoryActionController():
             res.error_code=FollowJointTrajectoryResult.INVALID_JOINTS
             msg = 'Incoming trajectory joints do not match the joints of the controller'
             rospy.logerr(msg)
-            rospy.logerr(' self.joint_names={}' % (set(self.joint_names)))
-            rospy.logerr(' traj.joint_names={}' % (set(traj.joint_names)))
+            rospy.logerr(' self.joint_names={%s}' % (set(self.joint_names)))
+            rospy.logerr(' traj.joint_names={%s}' % (set(traj.joint_names)))
             self.action_server.set_aborted(result=res, text=msg)
             return
             


### PR DESCRIPTION
Without this fix, I am getting the following additional error message when joint names do not match:
```
[ERROR] [1487327101.700549]: Incoming trajectory joints do not match the joints of the controller
[ERROR] [1487327101.701219]: Exception in your execute callback: not all arguments converted during string formatting
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/actionlib/simple_action_server.py", line 289, in executeLoop
```

And after this fix, I get:
```
[ERROR] [1487327182.210527]: Incoming trajectory joints do not match the joints of the controller
[ERROR] [1487327182.211012]:  self.joint_names={set(['y', 'x', 'rot', 'arm2', 'arm1'])}
...
```