### PR TITLE
Enable to ignore fatal errors

### DIFF
--- a/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
@@ -70,6 +70,7 @@ class JointController:
         self.compliance_margin = rospy.get_param(self.controller_namespace + '/joint_compliance_margin', None)
         self.compliance_punch = rospy.get_param(self.controller_namespace + '/joint_compliance_punch', None)
         self.torque_limit = rospy.get_param(self.controller_namespace + '/joint_torque_limit', None)
+        self.ignored_errors = rospy.get_param(self.controller_namespace + '/ignored_errors', None)
         
         self.__ensure_limits()
         
@@ -134,6 +135,9 @@ class JointController:
         raise NotImplementedError
 
     def set_torque_limit(self, max_torque):
+        raise NotImplementedError
+
+    def set_ignored_errors(self, errs):
         raise NotImplementedError
 
     def process_set_speed(self, req):

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -101,6 +101,9 @@ class JointPositionController(JointController):
             rospy.loginfo("Setting acceleration of %d to %d" % (self.motor_id, self.acceleration))
             self.dxl_io.set_acceleration(self.motor_id, self.acceleration)
 
+        if self.ignored_errors is not None:
+            self.set_ignored_errors(self.ignored_errors)
+
         self.joint_max_speed = rospy.get_param(self.controller_namespace + '/joint_max_speed', self.MAX_VELOCITY)
         
         if self.joint_max_speed < self.MIN_VELOCITY: self.joint_max_speed = self.MIN_VELOCITY
@@ -158,6 +161,9 @@ class JointPositionController(JointController):
         raw_torque_val = int(DXL_MAX_TORQUE_TICK * max_torque)
         mcv = (self.motor_id, raw_torque_val)
         self.dxl_io.set_multi_torque_limit([mcv])
+
+    def set_ignored_errors(self, errs):
+        self.dxl_io.set_ignored_errors(self.motor_id, errs)
 
     def set_acceleration_raw(self, acc):
         if acc < 0: acc = 0

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller_dual_motor.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller_dual_motor.py
@@ -98,6 +98,9 @@ class JointPositionControllerDual(JointController):
         if self.compliance_punch is not None: self.set_compliance_punch(self.compliance_punch)
         if self.torque_limit is not None: self.set_torque_limit(self.torque_limit)
         
+        if self.ignored_errors is not None:
+            self.set_ignored_errors(self.ignored_errors)
+
         self.joint_max_speed = rospy.get_param(self.controller_namespace + '/joint_max_speed', self.MAX_VELOCITY)
         
         if self.joint_max_speed < self.MIN_VELOCITY: self.joint_max_speed = self.MIN_VELOCITY
@@ -174,6 +177,10 @@ class JointPositionControllerDual(JointController):
         mcv_master = (self.master_id, raw_torque_val)
         mcv_slave = (self.slave_id, raw_torque_val)
         self.dxl_io.set_multi_torque_limit([mcv_master, mcv_slave])
+
+    def set_ignored_errors(self, errs):
+        self.dxl_io.set_ignored_errors(self.master_id, errs)
+        self.dxl_io.set_ignored_errors(self.slave_id, errs)
 
     def process_motor_states(self, state_list):
         if self.running:

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_torque_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_torque_controller.py
@@ -96,6 +96,9 @@ class JointTorqueController(JointController):
         if self.compliance_punch is not None: self.set_compliance_punch(self.compliance_punch)
         if self.torque_limit is not None: self.set_torque_limit(self.torque_limit)
         
+        if self.ignored_errors is not None:
+            self.set_ignored_errors(self.ignored_errors)
+
         self.joint_max_speed = rospy.get_param(self.controller_namespace + '/joint_max_speed', self.MAX_VELOCITY)
         
         if self.joint_max_speed < self.MIN_VELOCITY: self.joint_max_speed = self.MIN_VELOCITY
@@ -148,6 +151,9 @@ class JointTorqueController(JointController):
         raw_torque_val = int(DXL_MAX_TORQUE_TICK * max_torque)
         mcv = (self.motor_id, raw_torque_val)
         self.dxl_io.set_multi_torque_limit([mcv])
+
+    def set_ignored_errors(self, errs):
+        self.dxl_io.set_ignored_errors(self.motor_id, errs)
 
     def process_motor_states(self, state_list):
         if self.running:

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_torque_controller_dual_motor.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_torque_controller_dual_motor.py
@@ -98,6 +98,9 @@ class JointTorqueControllerDualMotor(JointController):
         if self.compliance_punch is not None: self.set_compliance_punch(self.compliance_punch)
         if self.torque_limit is not None: self.set_torque_limit(self.torque_limit)
         
+        if self.ignored_errors is not None:
+            self.set_ignored_errors(self.ignored_errors)
+
         self.joint_max_speed = rospy.get_param(self.controller_namespace + '/joint_max_speed', self.MAX_VELOCITY)
         
         if self.joint_max_speed < self.MIN_VELOCITY: self.joint_max_speed = self.MIN_VELOCITY
@@ -160,6 +163,11 @@ class JointTorqueControllerDualMotor(JointController):
         mcv_master = (self.master_id, raw_torque_val)
         mcv_slave = (self.slave_id, raw_torque_val)
         self.dxl_io.set_multi_torque_limit([mcv_master, mcv_slave])
+
+
+    def set_ignored_errors(self, errs):
+        self.dxl_io.set_ignored_errors(self.master_id, errs)
+        self.dxl_io.set_ignored_errors(self.slave_id, errs)
 
 
     def process_motor_states(self, state_list):


### PR DESCRIPTION
When a Dynamixel motor detects some dangerous situations, the motor goes torque off:
https://emanual.robotis.com/docs/en/dxl/mx/mx-28/#shutdown
However, we sometimes want the motor to ignore the error and continue working.
For example, when we use the motor in robotic fingers and these fingers grasp an object, these fingers should continue exerting strong force not to drop the object.
In that situation, the motor continues detecting a big load, easily goes into `Overload Error`, and torque off.

To avoid this problem, we can remove errors from `Shutdown` (and `Alarm LED`) register of the motor to prevent torque off due to these errors.
However, even when we do that, these errors are included in every response from the motor.
dynamixel_motor detects them and prints many error messages (especially when `Overload Error`):
https://github.com/arebgun/dynamixel_motor/blob/3d842328641a8c62f90388a254e5efb12929c1ae/dynamixel_driver/src/dynamixel_driver/dynamixel_io.py#L985-L1005
https://github.com/arebgun/dynamixel_motor/blob/3d842328641a8c62f90388a254e5efb12929c1ae/dynamixel_driver/src/dynamixel_driver/dynamixel_serial_proxy.py#L228-L238

This PR enables to suppress that phenomenon by setting rosparam.